### PR TITLE
Add return types to fix PHP 8.1+ deprecations.

### DIFF
--- a/src/Internal/SourceBuffer.php
+++ b/src/Internal/SourceBuffer.php
@@ -34,7 +34,7 @@ class SourceBuffer implements Iterator
         }
     }
 
-    public function current()
+    public function current(): ?string
     {
         if (!$this->valid()) {
             return null;
@@ -43,7 +43,7 @@ class SourceBuffer implements Iterator
         return $this->buffer[$this->bufferPosition];
     }
 
-    public function next()
+    public function next(): void
     {
         $this->bufferPosition++;
         if ($this->bufferPosition == min($this->bufferMaxSize, $this->bufferSize)) {
@@ -54,18 +54,18 @@ class SourceBuffer implements Iterator
         }
     }
 
-    public function key()
+    public function key(): int
     {
         return $this->sourcePosition;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return $this->buffer !== null
             && $this->bufferPosition < $this->bufferSize;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->source->rewind();
         $this->nextBuffer();

--- a/src/Tokenizer.php
+++ b/src/Tokenizer.php
@@ -36,7 +36,7 @@ class Tokenizer implements IteratorAggregate
      * @psalm-return \Traversable<Token>
      * @throws TokenizerException
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return $this->tokens();
     }


### PR DESCRIPTION
This fixes https://github.com/klkvsk/json-decode-stream/issues/2. I'm using this library in one of my projects and discovered the same issue (https://github.com/k8s-client/client). These changes are safe with the current PHP version constraint on this library.